### PR TITLE
Add unit tests for BookingRepository

### DIFF
--- a/BookingServiceProvider.sln
+++ b/BookingServiceProvider.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.13.35806.99 d17.13
+VisualStudioVersion = 17.13.35806.99
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Presentation", "Presentation\Presentation.csproj", "{C788BEBF-C46A-44B0-BAAC-E00BEA00EB88}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Data", "Data\Data.csproj", "{49824EEF-ECE6-4D31-81C9-03D045C25E60}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Business", "Business\Business.csproj", "{E6EDB3A0-2E78-4862-8834-7B5AF2EAB56E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{6148DB14-E1F5-46D3-B4AA-DE026079AFEC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{E6EDB3A0-2E78-4862-8834-7B5AF2EAB56E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E6EDB3A0-2E78-4862-8834-7B5AF2EAB56E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E6EDB3A0-2E78-4862-8834-7B5AF2EAB56E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6148DB14-E1F5-46D3-B4AA-DE026079AFEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6148DB14-E1F5-46D3-B4AA-DE026079AFEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6148DB14-E1F5-46D3-B4AA-DE026079AFEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6148DB14-E1F5-46D3-B4AA-DE026079AFEC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/Repositories/BookingRepositoryTests.cs
+++ b/Tests/Repositories/BookingRepositoryTests.cs
@@ -1,0 +1,64 @@
+﻿using Xunit;
+using FluentAssertions;
+using Data.Repositories;
+using Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Data.Contexts;
+namespace BookingTests.Repositories;
+
+public class BookingRepositoryTests
+{
+    private readonly DataContext _context;
+    private readonly BookingRepository _repository;
+
+    public BookingRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<DataContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new DataContext(options);
+        _repository = new BookingRepository(_context);
+
+        SeedData();
+    }
+
+    private void SeedData()
+    {
+        var booking = new BookingEntity
+        {
+            Id = Guid.NewGuid().ToString(),
+            EventId = Guid.NewGuid(),
+            BookingDate = DateTime.Now,
+            TicketQuantity = 2,
+            BookingOwner = new BookingOwnerEntity
+            {
+                Id = Guid.NewGuid().ToString(),
+                FirstName = "Test",
+                LastName = "User",
+                Email = "test@example.com",
+                Address = new BookingAddressEntity
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    StreetName = "Gatan 1",
+                    PostalCode = "12345",
+                    City = "Teststad"
+                }
+            }
+        };
+
+        _context.Bookings.Add(booking);
+        _context.SaveChanges();
+    }
+
+    [Fact]
+    public async Task GetByEmailAsync_Should_Return_Correct_Booking()
+    {
+        var result = await _repository.GetByEmailAsync("test@example.com");
+
+        result.Success.Should().BeTrue();
+        result.Result.Should().NotBeNull();
+        result.Result!.Count().Should().Be(1);
+        result.Result.First().BookingOwner.Email.Should().Be("test@example.com");
+    }
+}

--- a/Tests/Services/BookingsServiceTest.cs
+++ b/Tests/Services/BookingsServiceTest.cs
@@ -1,0 +1,124 @@
+﻿using Xunit;
+using Moq;
+using FluentAssertions;
+using Business.Services;
+using Data.Entities;
+using Data.Repositories;
+using Business.Models;
+using Data;
+using System.Linq.Expressions;
+
+namespace BookingTests.Services;
+
+public class BookingServiceTests
+{
+    private readonly Mock<IBookingRepository> _bookingRepoMock = new();
+    private readonly Mock<IBookingOwnerRepository> _ownerRepoMock = new();
+    private readonly Mock<IBookingAddressRepository> _addressRepoMock = new();
+    private readonly BookingService _service;
+
+    public BookingServiceTests()
+    {
+        _service = new BookingService(_bookingRepoMock.Object, _ownerRepoMock.Object, _addressRepoMock.Object);
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_Should_Return_Success_When_Valid()
+    {
+        var request = new CreateBookingRequest
+        {
+            EventId = Guid.NewGuid(),
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = "jane@example.com",
+            StreetName = "Main St",
+            PostalCode = "12345",
+            City = "Cityville",
+            TicketQuantity = 2
+        };
+
+        _bookingRepoMock.Setup(repo => repo.AddAsync(It.IsAny<BookingEntity>()))
+            .ReturnsAsync(new RepositoryResult<bool> { Success = true });
+
+        var result = await _service.CreateBookingAsync(request);
+
+        result.Success.Should().BeTrue();
+        result.Error.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateBookingAsync_Should_Return_Failure_When_Add_Fails()
+    {
+        var request = new CreateBookingRequest
+        {
+            EventId = Guid.NewGuid(),
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = "jane@example.com",
+            StreetName = "Main St",
+            PostalCode = "12345",
+            City = "Cityville",
+            TicketQuantity = 2
+        };
+
+        _bookingRepoMock.Setup(repo => repo.AddAsync(It.IsAny<BookingEntity>()))
+            .ReturnsAsync(new RepositoryResult<bool> { Success = false, Error = "DB Error" });
+
+        var result = await _service.CreateBookingAsync(request);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("DB Error");
+    }
+
+    [Fact]
+    public async Task GetBookingsByEmailAsync_Should_Return_Result_When_Found()
+    {
+        var bookings = new List<BookingEntity> {
+            new BookingEntity { Id = "b1", EventId = Guid.NewGuid(), TicketQuantity = 1 }
+        };
+
+        _bookingRepoMock.Setup(repo => repo.GetByEmailAsync("test@example.com"))
+            .ReturnsAsync(new RepositoryResult<IEnumerable<BookingEntity>> { Success = true, Result = bookings });
+
+        var result = await _service.GetBookingsByEmailAsync("test@example.com");
+
+        result.Success.Should().BeTrue();
+        result.Result.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task DeleteFullBookingAsync_Should_Delete_When_Exists()
+    {
+        var bookingId = "b1";
+        var owner = new BookingOwnerEntity
+        {
+            Id = "o1",
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = "jane@example.com",
+            Address = new BookingAddressEntity
+            {
+                Id = "a1",
+                StreetName = "Main St",
+                City = "City",
+                PostalCode = "12345"
+            }
+        };
+        var booking = new BookingEntity { Id = bookingId, BookingOwner = owner };
+
+        _bookingRepoMock.Setup(r => r.GetAsync(It.IsAny<Expression<Func<BookingEntity, bool>>>()))!
+            .ReturnsAsync(new RepositoryResult<BookingEntity> { Success = true, Result = booking });
+        _bookingRepoMock.Setup(r => r.DeleteAsync(booking))
+            .ReturnsAsync(new RepositoryResult<bool> { Success = true });
+        _ownerRepoMock.Setup(r => r.DeleteAsync(owner))
+            .ReturnsAsync(new RepositoryResult<bool> { Success = true });
+        _addressRepoMock.Setup(r => r.DeleteAsync(owner.Address))
+            .ReturnsAsync(new RepositoryResult<bool> { Success = true });
+
+        var result = await _service.DeleteFullBookingAsync(bookingId);
+
+        result.Success.Should().BeTrue();
+    }
+    
+
+    }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.3.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Business\Business.csproj" />
+    <ProjectReference Include="..\Data\Data.csproj" />
+    <ProjectReference Include="..\Presentation\Presentation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
 BookingServiceTests
 CreateBookingAsync – tests for both success and failure when adding a booking

 GetBookingsByEmailAsync – ensures correct retrieval of bookings by email

DeleteFullBookingAsync – verifies cascading delete behavior for Booking, Owner, and Address

 BookingRepositoryTests
 In-memory DataContext setup

 Seeded test data for realistic test scenarios

 GetByEmailAsync – confirms the method returns the correct booking with associated entities